### PR TITLE
feat(zoho oauth): added zoho oauth 2.0 implementation

### DIFF
--- a/lib/zoho-sdk/analytics/client.rb
+++ b/lib/zoho-sdk/analytics/client.rb
@@ -9,7 +9,7 @@ module ZohoSdk::Analytics
   API_BASE_URL = "#{API_HOSTNAME}/#{API_PATH}".freeze
 
   # URL to retrieve access token
-  API_AUTH_HOSTNAME = "https//accounts.zoho.com".freeze
+  API_AUTH_HOSTNAME = "https://accounts.zoho.com".freeze
   API_AUTH_PATH = "oauth/v2/token".freeze
   API_AUTH_BASE_URL = "#{API_AUTH_HOSTNAME}/#{API_AUTH_PATH}".freeze
 

--- a/lib/zoho-sdk/analytics/client.rb
+++ b/lib/zoho-sdk/analytics/client.rb
@@ -8,19 +8,50 @@ module ZohoSdk::Analytics
   API_PATH = "api".freeze
   API_BASE_URL = "#{API_HOSTNAME}/#{API_PATH}".freeze
 
+  # URL to retrieve access token
+  API_AUTH_HOSTNAME = "https//accounts.zoho.com".freeze
+  API_AUTH_PATH = "oauth/v2/token".freeze
+  API_AUTH_BASE_URL = "#{API_AUTH_HOSTNAME}/#{API_AUTH_PATH}".freeze
+
   # Allows retrieving workspaces, metadata, and other general data not tied
   # to a specific resource.
   class Client
-    def initialize(email, auth_token)
+    def initialize(email, client_id, client_secret, refresh_token)
       @email = email
-      @auth_token = auth_token
+      @client_id = client_id
+      @client_secret = client_secret
+      @refresh_token = refresh_token
+
+      # Retrieves access token to authenticate all API requests
+      conn =
+        Faraday.new(url: API_AUTH_BASE_URL) { |conn| conn.adapter :net_http }
+      res =
+        conn.post do |req|
+          payload = {
+            "client_id" => @client_id,
+            "client_secret" => @client_secret,
+            "refresh_token" => @refresh_token,
+            "grant_type" => "refresh_token"
+          }
+          payload.each { |key, value| req.params[key] = value }
+        end
+      if res.success?
+        data = JSON.parse(res.body)
+        if data["access_token"]
+          @access_token = data["access_token"]
+        else
+          nil
+        end
+      else
+        nil
+      end
     end
 
     def workspace_metadata
       get params: {
-        "ZOHO_ACTION" => "DATABASEMETADATA",
-        "ZOHO_METADATA" => "ZOHO_CATALOG_LIST"
-      }
+            "ZOHO_ACTION" => "DATABASEMETADATA",
+            "ZOHO_METADATA" => "ZOHO_CATALOG_LIST"
+          }
     end
 
     # Create a new Zoho Analytics workspace
@@ -29,11 +60,12 @@ module ZohoSdk::Analytics
     # @option opts [String] :description Workspace description
     # @return [Workspace] Newly created Workspace
     def create_workspace(name, **opts)
-      res = get params: {
-        "ZOHO_ACTION" => "CREATEBLANKDB",
-        "ZOHO_DATABASE_NAME" => name,
-        "ZOHO_DATABASE_DESC" => opts[:description] || ""
-      }
+      res =
+        get params: {
+              "ZOHO_ACTION" => "CREATEBLANKDB",
+              "ZOHO_DATABASE_NAME" => name,
+              "ZOHO_DATABASE_DESC" => opts[:description] || ""
+            }
       if res.success?
         data = JSON.parse(res.body)
         Workspace.new(name, self)
@@ -46,10 +78,7 @@ module ZohoSdk::Analytics
     # @param name [String] The workspace name
     # @return [Workspace]
     def workspace(name)
-      res = get params: {
-        "ZOHO_ACTION" => "ISDBEXIST",
-        "ZOHO_DB_NAME" => name
-      }
+      res = get params: { "ZOHO_ACTION" => "ISDBEXIST", "ZOHO_DB_NAME" => name }
       if res.success?
         data = JSON.parse(res.body)
         if data.dig("response", "result", "isdbexist") == "true"
@@ -67,16 +96,20 @@ module ZohoSdk::Analytics
     # @param params [Hash] Query parameters for the request
     # @return [Faraday::Response]
     def get(path: nil, params: {})
-      conn = Faraday.new(url: url_for(path))
-      res = conn.get do |req|
-        req.params["ZOHO_OUTPUT_FORMAT"] = "JSON"
-        req.params["ZOHO_ERROR_FORMAT"] = "JSON"
-        req.params["ZOHO_API_VERSION"] = "1.0"
-        req.params["authtoken"] = @auth_token
-        params.each { |key, value|
-          req.params[key] = value
-        }
-      end
+      conn =
+        Faraday.new(url: url_for(path)) do |conn|
+          conn.adapter :net_http
+          conn.headers = {
+            "Authorization" => "Zoho-oauthtoken #{@access_token}"
+          }
+        end
+      res =
+        conn.get do |req|
+          req.params["ZOHO_OUTPUT_FORMAT"] = "JSON"
+          req.params["ZOHO_ERROR_FORMAT"] = "JSON"
+          req.params["ZOHO_API_VERSION"] = "1.0"
+          params.each { |key, value| req.params[key] = value }
+        end
     end
 
     # Wrapper for posting JSON via Faraday. Used primarily for IMPORT tasks.
@@ -85,27 +118,28 @@ module ZohoSdk::Analytics
     # @param params [Hash] Query parameters for the request
     # @return [Faraday::Response]
     def post_json(path: nil, io:, params: {})
-      conn = Faraday.new(url: url_for(path)) do |conn|
-        conn.request :multipart
-        conn.adapter :net_http
-        conn.headers = {
-          'Content-Type' => 'multipart/form-data'
-        }
-      end
-      res = conn.post do |req|
-        payload = {
-          "ZOHO_OUTPUT_FORMAT" => "JSON",
-          "ZOHO_ERROR_FORMAT" => "JSON",
-          "ZOHO_API_VERSION" => "1.0",
-          "authtoken" => @auth_token
-        }
-        params.merge(payload).each { |key, value|
-          req.params[key] = value
-        }
-        req.body = {
-          "ZOHO_FILE" => Faraday::FilePart.new(io, "application/json", "ZOHO_FILE.json")
-        }
-      end
+      conn =
+        Faraday.new(url: url_for(path)) do |conn|
+          conn.request :multipart
+          conn.adapter :net_http
+          conn.headers = {
+            "Authorization" => "Zoho-oauthtoken #{@access_token}",
+            "Content-Type" => "multipart/form-data"
+          }
+        end
+      res =
+        conn.post do |req|
+          payload = {
+            "ZOHO_OUTPUT_FORMAT" => "JSON",
+            "ZOHO_ERROR_FORMAT" => "JSON",
+            "ZOHO_API_VERSION" => "1.0"
+          }
+          params.merge(payload).each { |key, value| req.params[key] = value }
+          req.body = {
+            "ZOHO_FILE" =>
+              Faraday::FilePart.new(io, "application/json", "ZOHO_FILE.json")
+          }
+        end
     end
 
     # Helper function to build a complete URL path that includes email ID
@@ -113,9 +147,7 @@ module ZohoSdk::Analytics
     def url_for(path = nil)
       parts = [API_BASE_URL, @email]
       if !path.nil?
-        if path[0] == "/"
-          path = path[1..-1]
-        end
+        path = path[1..-1] if path[0] == "/"
         parts << path
       end
       URI.encode(parts.join("/"))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ SimpleCov.start
 require "bundler/setup"
 require "webmock/rspec"
 require "support/analytics"
+require "support/analytics/auth_service"
 require "support/analytics/service"
 require "zoho-sdk"
 
@@ -54,6 +55,11 @@ RSpec.configure do |config|
         :any,
         %r{#{Regexp.escape(ZohoSdk::Analytics::API_HOSTNAME)}\/.*}
       ).to_rack(ZohoSdk::TestService::Analytics::Service)
+
+      stub_request(
+        :post,
+        %r{#{Regexp.escape(ZohoSdk::Analytics::API_AUTH_HOSTNAME)}\/.*}
+      ).to_rack(ZohoSdk::TestService::Analytics::AuthService)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,9 @@ require "support/analytics"
 require "support/analytics/service"
 require "zoho-sdk"
 
-stub = ENV["SPEC_ZOHO_EMAIL"].nil? || ENV["SPEC_ZOHO_AUTHTOKEN"].nil?
+stub =
+  ENV["SPEC_ZOHO_EMAIL"].nil? || ENV["SPEC_ZOHO_CLIENT_ID"].nil? ||
+    ENV["SPEC_ZOHO_CLIENT_SECRET"].nil? || ENV["SPEC_ZOHO_REFRESH_TOKEN"].nil?
 
 if stub
   WebMock.disable_net_connect!(allow_localhost: true)
@@ -20,8 +22,17 @@ module GlobalContext
   extend RSpec::SharedContext
 
   let(:email) { ENV["SPEC_ZOHO_EMAIL"] || "user@email.com" }
-  let(:auth_token) { ENV["SPEC_ZOHO_AUTHTOKEN"] || "authtoken" }
-  let(:client) { ZohoSdk::Analytics::Client.new(email, auth_token) }
+  let(:client_id) { ENV["SPEC_ZOHO_CLIENT_ID"] || "client_id" }
+  let(:client_secret) { ENV["SPEC_ZOHO_CLIENT_SECRET"] || "client_secret" }
+  let(:refresh_token) { ENV["SPEC_ZOHO_REFRESH_TOKEN"] || "refresh_token" }
+  let(:client) do
+    ZohoSdk::Analytics::Client.new(
+      email,
+      client_id,
+      client_secret,
+      refresh_token
+    )
+  end
 end
 
 RSpec.configure do |config|
@@ -39,7 +50,10 @@ RSpec.configure do |config|
 
   if stub
     config.before(:each) do
-      stub_request(:any, /#{Regexp.escape(ZohoSdk::Analytics::API_HOSTNAME)}\/.*/).to_rack(ZohoSdk::TestService::Analytics::Service)
+      stub_request(
+        :any,
+        %r{#{Regexp.escape(ZohoSdk::Analytics::API_HOSTNAME)}\/.*}
+      ).to_rack(ZohoSdk::TestService::Analytics::Service)
     end
   end
 end

--- a/spec/support/analytics/auth_service.rb
+++ b/spec/support/analytics/auth_service.rb
@@ -1,0 +1,17 @@
+require "sinatra/base"
+require "support/analytics/method"
+
+module ZohoSdk
+  module TestService
+    module Analytics
+      class AuthService < Sinatra::Base
+        post "/oauth/v2/token" do
+          # TODO: Verify response format & return code (should be 200 but YNK)
+          content_type :json
+          status 200
+          { data: { access_token: "access_token" } }.to_json
+        end
+      end
+    end
+  end
+end

--- a/spec/support/analytics/service.rb
+++ b/spec/support/analytics/service.rb
@@ -6,52 +6,43 @@ module ZohoSdk
     module Analytics
       class Service < Sinatra::Base
         get "/api/:email" do
-          [
-            WorkspaceMetadata,
-            IsWorkspaceExist
-          ].each { |method|
+          [WorkspaceMetadata, IsWorkspaceExist].each do |method|
             m = method.new(method_params)
-            if m.match?
-              return json_response m.status, m.response.to_json
-            end
-          }
+            return json_response m.status, m.response.to_json if m.match?
+          end
 
           status 404
         end
 
         get "/api/:email/:workspace" do
-          [
-            IsViewExist
-          ].each { |method|
+          [IsViewExist].each do |method|
             m = method.new(method_params)
-            if m.match?
-              return json_response m.status, m.response.to_json
-            end
-          }
+            return json_response m.status, m.response.to_json if m.match?
+          end
 
           status 404
         end
 
         get "/api/:email/:workspace/:table" do
-          [
-            IsColumnExist
-          ].each { |method|
+          [IsColumnExist].each do |method|
             m = method.new(method_params)
-            if m.match?
-              return json_response m.status, m.response.to_json
-            end
-          }
+            return json_response m.status, m.response.to_json if m.match?
+          end
 
           status 404
         end
 
         def method_params
-          params.reject { |key, value|
-            %w(
-              email workspace table ZOHO_API_VERSION ZOHO_OUTPUT_FORMAT
-              ZOHO_ERROR_FORMAT authtoken
-            ).include?(key)
-          }
+          params.reject do |key, value|
+            %w[
+              email
+              workspace
+              table
+              ZOHO_API_VERSION
+              ZOHO_OUTPUT_FORMAT
+              ZOHO_ERROR_FORMAT
+            ].include?(key)
+          end
         end
 
         def json_response(status_code, json)


### PR DESCRIPTION
- Gets client ID, client secret, and refresh token from environment variables
- Creates an access token to authenticate API requests when initializing the client
- Passes access token as a header in API requests
- Uses a single access token to avoid Zoho's limitation on number of access tokens created in a certain time span